### PR TITLE
Move make targets to scripts and add coverage with coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 public/bower_components/
 node_modules/
 vendor/
+coverage.out
+combined_coverage.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.6-alpine
 
-RUN apk add --update --no-cache git nodejs curl
+RUN apk add --update --no-cache git nodejs curl gcc musl-dev
 RUN npm install -g bower eslint
 
 ENV GLIDE_VERSION 0.11.1
@@ -9,7 +9,8 @@ RUN curl -sSL https://github.com/Masterminds/glide/releases/download/v$GLIDE_VER
     && mv linux-386/glide /usr/local/bin \
     && rm -rf glide.tar.gz linux-386
 
-RUN go get -u github.com/jteeuwen/go-bindata/...
+RUN go get -u github.com/jteeuwen/go-bindata/... \
+  && go get github.com/mattn/goveralls
 
 RUN mkdir -p /go/src/github.com/MEDIGO/laika
 WORKDIR /go/src/github.com/MEDIGO/laika

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laika
 
-[![CircleCI](https://circleci.com/gh/MEDIGO/laika.svg?style=shield)](https://circleci.com/gh/MEDIGO/laika)
+[![CircleCI](https://circleci.com/gh/MEDIGO/laika.svg?style=shield)](https://circleci.com/gh/MEDIGO/laika) [![Coverage Status](https://coveralls.io/repos/github/MEDIGO/laika/badge.svg)](https://coveralls.io/github/MEDIGO/laika)
 
 Laika is a feature flag/feature toggle service, written in Go, that allows the creation of flags and their activation/deactivation for specific environments. This way it is possible to control in which environments each feature is available. For instance, when a new feature is developed and released, it would make sense if it was only made available, at first, in a testing or Q&A environment, and only later in production. With Laika this can be achieved by simply going to a web page, selecting the feature, and changing its status on the desired environments.
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ dependencies:
 test:
     override:
         - make
+        - make report
 
 deployment:
     publish:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -19,6 +19,7 @@ services:
             LAIKA_TEST_MYSQL_DBNAME: laika
             LAIKA_STATSD_HOST: localhost
             LAIKA_STATSD_PORT: 812
+            COVERALLS_TOKEN:
     mysql:
         image: mysql:5
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
             LAIKA_STATSD_PORT: 8125
             LAIKA_ROOT_USERNAME: root
             LAIKA_ROOT_PASSWORD: root
+            COVERALLS_TOKEN:
         env_file: .env
         volumes:
             - ./:/go/src/github.com/MEDIGO/laika

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+commit=$(git rev-parse HEAD)
+
+docker pull medigo/laika:$(commit)
+aws ecs register-task-definition --family $(ECS_FAMILY) --container-definitions '$(shell ./ecs-container-definitions.sh)'
+aws ecs update-service --service $(ECS_FAMILY) --task-definition $(ECS_FAMILY)
+aws ecs wait services-stable --services $(ECS_FAMILY)

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+go-bindata -pkg schema -o store/schema/schema.go -ignore \.go store/schema/...

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+bower install --allow-root
+glide install

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+go vet $(go list ./... | grep -v vendor)
+eslint .

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+go run main.go migrate

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+commit=$(git rev-parse HEAD)
+
+docker tag medigo/laika:latest medigo/laika:$(commit)
+docker login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
+docker push medigo/laika:latest
+docker push medigo/laika:$(commit)

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o pipefail
+
+if [[ -x "${COVERALLS_TOKEN}" ]]; then
+  goveralls -coverprofile=combined_coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "mode: set" > combined_coverage.out
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -cover -coverprofile=coverage.out $d
+    if [ -f coverage.out ]; then
+        cat coverage.out | grep -h -v "^mode:" >> combined_coverage.out
+        rm coverage.out
+    fi
+done


### PR DESCRIPTION
This PR moves the makefile target into standalone scripts and adds coverage report with [coveralls.io](https://coveralls.io/)
