### PR TITLE
Show error message when port is already in use

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 				}
 
 				log.Info("Starting server on port ", c.GlobalString("port"))
-				graceful.Run(":"+c.GlobalString("port"), time.Duration(c.Int("timeout"))*time.Second, server)
+				log.Fatal(graceful.RunWithErr(":"+c.GlobalString("port"), time.Duration(c.Int("timeout"))*time.Second, server))
 				log.Info("Server exiting")
 				return nil
 			},


### PR DESCRIPTION
This PR closes issue #124 

There should now be a log message `address already in use` when there is a port conflict.
